### PR TITLE
Fix type deduction bug of to_hex

### DIFF
--- a/include/stx/string.h
+++ b/include/stx/string.h
@@ -306,8 +306,9 @@ std::string to_hex(_Iter begin, _Iter end, bool upcase = false)
 {
     const char* charset[2] = {"0123456789abcdef", "0123456789ABCDEF"};
 
-    static_assert(std::is_integral_v<typename _Iter::value_type>);
-    const auto type_size = sizeof(typename _Iter::value_type);
+    using ValueType = std::remove_reference_t<decltype(*begin)>;
+    static_assert(std::is_integral_v<ValueType>);
+    const auto type_size = sizeof(ValueType);
 
     std::string str;
     str.reserve(2u * std::distance(begin, end) * type_size);

--- a/test/src/string.cpp
+++ b/test/src/string.cpp
@@ -2,6 +2,8 @@
 
 #include "stx/string.h"
 
+#include <cstring>
+
 using namespace std::string_literals;
 
 SCENARIO("split a string into parts", "[stx::string::split]") {
@@ -247,6 +249,16 @@ TEST_CASE("Range to hex string", "[stx::string::to_hex]") {
 
         auto resl = stx::to_hex(str.begin(), str.end());
         auto resu = stx::to_hex(str.begin(), str.end(), true);
+
+        REQUIRE(resl == "48616c6c6f2057656c7421");
+        REQUIRE(resu == "48616C6C6F2057656C7421");
+    }
+
+    SECTION("c-string") {
+        auto str = "Hallo Welt!";
+
+        auto resl = stx::to_hex(str, str + std::strlen(str));
+        auto resu = stx::to_hex(str, str + std::strlen(str), true);
 
         REQUIRE(resl == "48616c6c6f2057656c7421");
         REQUIRE(resu == "48616C6C6F2057656C7421");


### PR DESCRIPTION
### Changes

Allow using non std-container iterators as input, such as pointers, by not relying on sub-types (`value_type`) of the iterator type but using `decltype(…)` instead.