### PR TITLE
Added missing iterator include

### DIFF
--- a/include/stx/string.h
+++ b/include/stx/string.h
@@ -7,6 +7,7 @@
 #include <numeric>
 #include <algorithm>
 #include <type_traits>
+#include <iterator>
 
 /* For optional Qt -> std conversions */
 #if defined(QT_CORE_LIB)


### PR DESCRIPTION
On MSVC, if the surrounding code has not imported iterator, the builds fail with "back_inserter not found".
