### PR TITLE
Implement stx::format

### DIFF
--- a/include/stx/format.h
+++ b/include/stx/format.h
@@ -1,0 +1,138 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <cstring>
+#include <algorithm>
+#include <charconv>
+
+#include "formatter.h"
+#include "format_impl.h"
+
+namespace stx
+{
+
+/**
+ * See `format`.
+ */
+template <class _Iter, class... _Args>
+_Iter format_to(_Iter out, std::string_view fmt, const _Args& ...args)
+{
+    std::tuple<const _Args&...> tuple(args...);
+
+    auto replace = [&tuple, next = 0u](auto begin, auto end, auto out) mutable {
+        std::size_t index = 0u;
+        std::string_view format;
+
+        if (begin == end)
+            return;
+
+        /* Parse optional argument index */
+        auto sv_begin = &(*begin);
+        if (auto r = std::from_chars(sv_begin, sv_begin + std::distance(begin, end), index); r.ptr != sv_begin) {
+            begin += r.ptr - sv_begin; /* MSVC does not accept: begin = r.ptr */
+        } else {
+            index = next++; /* Auto incr. index */
+        }
+
+        /* Parse optional argument format */
+        if (begin != end && *begin == ':') {
+            if (++begin != end) {
+                const auto format_len = std::max<size_t>(std::distance(begin, end), 1) - 1; /* end is +1 off (behind the closing brace) */
+                format = std::string_view(&(*begin), static_cast<std::string_view::size_type>(format_len));
+            }
+        }
+
+        format_impl::format_value_at(index, tuple, format, out);
+    };
+
+    /* NOTE: Nested braces are not (yet?) allowed. */
+    auto skip_format = [](auto begin, auto end) {
+        while (begin != end) {
+            if (*begin == '}') {
+                if (++begin == end)
+                    return begin;
+
+                /* Escape double r-brace. */
+                if (*begin != '}')
+                    return begin;
+            }
+
+            ++begin;
+        }
+
+        return begin;
+    };
+
+    auto begin = fmt.cbegin();
+    auto end = fmt.cend();
+
+    while (begin != end) {
+        if (*begin == '{') {
+            if (++begin == end)
+                break;
+
+            /* Escape double l-brace. */
+            if (*begin == '{') {
+                *out = *begin++;
+            } else {
+                auto fmt_end = skip_format(begin, end);
+                replace(begin, fmt_end, out);
+
+                begin = fmt_end;
+            }
+        } else if (*begin == '}') {
+            if (++begin == end)
+                break;
+
+            /* Escape double r-brace. */
+            if (*begin == '}') {
+                *out++ = *begin++;
+            }
+        } else {
+            *out++ = *begin++;
+        }
+    }
+
+    return out;
+}
+
+/**
+ * Safely format strings.
+ *
+ * @param fmt   Format string – see examples.
+ * @param args  Values to format.
+ * @return  The formatted string.
+ *
+ * See `format_to` for a version that uses an output iterator.
+ *
+ * Basic examples:
+ *   format("{}", 123) => "123"
+ *   format("{}, {}, {}", 1, "a", true) => "1, a, true"
+ *
+ * Index example:
+ *   format("{1} {0}", "a", 1) => "1 a"
+ *
+ * Format example:
+ *   By default, numbers are justified right, strings are justified left
+ *     format("{:5} {:5}", 123, "xx") => "  123 xx   "
+ *
+ *   Justification can be specified with <, > and ^ (left, right, center).
+ *   The fill-char can be specified as first argument.
+ *      format("{:0>5} {:_<6} {:.^3}", 123, "xx", 0) => "00123 xx____ .0."
+ *
+ * Nested {} as std::format supports them are not supported!
+ */
+template <class... _Args>
+std::string format(std::string_view fmt, const _Args& ...args)
+{
+    std::string out;
+    out.reserve(fmt.size());
+
+    format_to(std::back_inserter(out), fmt, args...);
+
+    return out;
+}
+
+}

--- a/include/stx/format_impl.h
+++ b/include/stx/format_impl.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <string_view>
+#include <charconv>
+#include <optional>
+
+#include "formatter.h"
+
+namespace stx::format_impl
+{
+
+/**
+ * Helper for calling formatter<T>::format on the n-the tuple element.
+ */
+template <size_t>
+struct format_value_at_t;
+
+template <size_t _Index>
+struct format_value_at_t
+{
+    /* NOTE: _Index is 1based, Index0 is 0based */
+    static constexpr auto Index0 = _Index - 1u;
+
+    template <class _Tuple, class _Iter>
+    static void format(size_t index, const _Tuple& t, std::string_view fmt, _Iter out)
+    {
+        if (index == Index0) {
+            formatter<std::decay_t<std::tuple_element_t<Index0, _Tuple>>> vf(fmt);
+            return vf.format(std::get<Index0>(t), out);
+        }
+
+        return format_value_at_t<_Index - 1 /* 1based */>::format(index, t, fmt, out);
+    }
+};
+
+template <>
+struct format_value_at_t<0u>
+{
+    template <class _Tuple, class _Iter>
+    static void format(size_t, const _Tuple&, std::string_view, _Iter)
+    {}
+};
+
+template <class _Tuple, class _Iter>
+void format_value_at(size_t index, const _Tuple& t, std::string_view fmt, _Iter out)
+{
+    format_value_at_t<std::tuple_size_v<_Tuple>>::format(index, t, fmt, out);
+}
+
+}

--- a/include/stx/formatter.h
+++ b/include/stx/formatter.h
@@ -7,6 +7,8 @@
 #include <charconv>
 #include <type_traits>
 
+#include "string.h"
+
 namespace stx
 {
 
@@ -230,5 +232,20 @@ struct formatter<const char*> : formatter<std::string_view>
         return formatter<std::string_view>::format(value, out);
     }
 };
+
+#if defined(QT_CORE_LIB)
+template <class _Type>
+struct formatter<_Type, std::enable_if_t<std::is_same_v<_Type, QString> ||
+                                         std::is_same_v<_Type, QUuid>>> : formatter<std::string_view>
+{
+    using formatter<std::string_view>::formatter;
+
+    template <class _Iter>
+    void format(const _Type& value, _Iter out)
+    {
+        return formatter<std::string_view>::format(stx::to_string(value), out);
+    }
+};
+#endif
 
 }

--- a/include/stx/formatter.h
+++ b/include/stx/formatter.h
@@ -42,6 +42,9 @@ struct formatter_base
     template <class _T>
     static std::optional<_T> eat_number(std::string_view& sv)
     {
+        if (sv.empty())
+            return {};
+
         _T v;
         /* Msvc needs this super stupic iter->ptr conversion. */
         auto begin = &(*sv.begin());

--- a/include/stx/formatter.h
+++ b/include/stx/formatter.h
@@ -1,0 +1,231 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <optional>
+#include <algorithm>
+#include <charconv>
+#include <type_traits>
+
+namespace stx
+{
+
+/**
+ * Non-virtual formatter base for sharing functionality.
+ */
+struct formatter_base
+{
+    std::optional<char> fillc;
+    std::optional<char> justify;
+    std::optional<size_t> min_width;
+
+    /**
+     * Eat the first char from string_view `sv` if contained in `in`
+     * or if `in` is unset.
+    */
+    static std::optional<char> eat_char(std::string_view& sv, std::string_view in)
+    {
+        if (sv.empty())
+            return {};
+
+        auto c = sv.front();
+        if (!in.empty() && in.find(c) == std::string_view::npos)
+            return {};
+
+        sv.remove_prefix(1);
+        return c;
+    }
+
+    /**
+     * Eat the first number of type _T from string_view `sv`
+     */
+    template <class _T>
+    static std::optional<_T> eat_number(std::string_view& sv)
+    {
+        _T v;
+        /* Msvc needs this super stupic iter->ptr conversion. */
+        auto begin = &(*sv.begin());
+        auto r = std::from_chars(begin, begin + sv.size(), v);
+        if (r.ptr == begin)
+            return {};
+
+        sv.remove_prefix(r.ptr - begin);
+        return v;
+    }
+
+    /**
+     * Formatter base ctor
+     *
+     * Parsing all generic/universal formatting options.
+     * Child classes must call justify_pre and justify_post
+     * before and after writing their values.
+     */
+    formatter_base(std::string_view& fmt)
+    {
+        /* {:[.][<>^][0-9]...} */
+        if (fmt.find_first_of("<^>") == 1u) {
+            fillc = eat_char(fmt, {});
+            justify = eat_char(fmt, "<^>");
+        /* {:[<>^][0-9]} */
+        } else if (fmt.find_first_of("<^>") == 0u) {
+            justify = eat_char(fmt, "<^>");
+        }
+
+        /* {:[0-9]} */
+        min_width = eat_number<unsigned>(fmt);
+
+        /* {:[.]} */
+        if (!fillc && !min_width)
+            fillc = eat_char(fmt, {});
+    }
+
+    template <class _Iter>
+    void justify_pre(size_t width, _Iter out)
+    {
+        if (justify == '>') {
+            if (width < min_width && min_width)
+                std::fill_n(out, *min_width - width, fillc.value_or(' '));
+        } else if (justify == '^') {
+            if (width < min_width)
+                std::fill_n(out, (*min_width - width) / 2, fillc.value_or(' '));
+        } else if (justify == '<') {
+            /* Special case: Prepend 1 fillc if value is non-empty.
+             * Why? This supports a handy trick to prepend a space to non-empty values.
+             * E.g. format("Hello{: }.", name) -> "Hello." or "Hello Johannes." */
+            if (!min_width && fillc && width > 0)
+                *out++ = *fillc;
+        }
+    }
+
+    template <class _Iter>
+    void justify_post(size_t width, _Iter out)
+    {
+        if (justify == '<') {
+            if (width < min_width)
+                std::fill_n(out, *min_width - width, fillc.value_or(' '));
+        } else if (justify == '^') {
+            if (width < min_width)
+                std::fill_n(out, (*min_width - width) / 2 + ((*min_width - width) % 2), fillc.value_or(' '));
+        } else if (justify == '>') {
+            /* See `justify_pre` comment. */
+            if (!min_width && fillc && width > 0)
+                *out++ = *fillc;
+        }
+    }
+};
+
+/**
+ * Type formatters.
+ */
+template <class, class _Enable = void>
+struct formatter;
+
+template <>
+struct formatter<bool> : formatter_base
+{
+    using formatter_base::formatter_base;
+
+    template <class _Iter>
+    void format(bool value, _Iter out)
+    {
+        static const char* s[] = {"false", "true"};
+        const auto size = value ? 4 : 5;
+
+        justify_pre(size, out);
+        std::copy_n(s[!!value], size, out);
+        justify_post(size, out);
+    }
+};
+
+template <class _Type>
+struct formatter<_Type, std::enable_if_t<std::is_floating_point_v<_Type>>> : formatter_base
+{
+    using formatter_base::formatter_base;
+
+    formatter(std::string_view& sv)
+        : formatter_base(sv)
+    {
+        if (!justify)
+            justify = '>';
+    }
+
+    template <class _Iter>
+    void format(_Type value, _Iter out)
+    {
+        char buffer[30];
+
+        const auto res = std::to_chars(buffer, buffer + sizeof(buffer), value);
+        const auto size = res.ptr - buffer;
+
+        justify_pre(size, out);
+        std::copy_n(buffer, size, out);
+        justify_post(size, out);
+    }
+};
+
+
+template <class _Type>
+struct formatter<_Type, std::enable_if_t<std::is_integral_v<_Type>>> : formatter_base
+{
+    int base = 10;
+
+    formatter(std::string_view& sv)
+        : formatter_base(sv)
+    {
+        if (!justify)
+            justify = '>';
+
+        auto base_ident = formatter_base::eat_char(sv, "xdob").value_or('d');
+        base = base_ident == 'x' ? 16 :
+               base_ident == 'd' ? 10 :
+               base_ident == 'o' ? 8 :
+               base_ident == 'b' ? 2 : 10;
+    }
+
+    template <class _Iter>
+    void format(_Type value, _Iter out)
+    {
+        char buffer[30];
+
+        auto res = std::to_chars(buffer, buffer + sizeof(buffer), value, base);
+        const auto size = res.ptr - buffer;
+
+        justify_pre(size, out);
+        std::copy_n(buffer, size, out);
+        justify_post(size, out);
+    }
+};
+
+template <class _Type>
+struct formatter<_Type, std::enable_if_t<std::is_same_v<_Type, std::string_view> ||
+                                         std::is_same_v<_Type, std::string>>> : formatter_base
+{
+    formatter(std::string_view& sv)
+        : formatter_base(sv)
+    {
+        if (!justify)
+            justify = '<';
+    }
+
+    template <class _Iter>
+    void format(const _Type& value, _Iter out)
+    {
+        justify_pre(value.size(), out);
+        std::copy(value.begin(), value.end(), out);
+        justify_post(value.size(), out);
+    }
+};
+
+template <>
+struct formatter<const char*> : formatter<std::string_view>
+{
+    using formatter<std::string_view>::formatter;
+
+    template <class _Iter>
+    void format(const char* value, _Iter out)
+    {
+        return formatter<std::string_view>::format(value, out);
+    }
+};
+
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,6 +8,7 @@ endif()
 add_executable(stx-test
   src/main.cpp
   src/string.cpp
+  src/format.cpp
   src/map.cpp)
 
 target_compile_options(stx-test

--- a/test/src/format.cpp
+++ b/test/src/format.cpp
@@ -1,0 +1,145 @@
+#include <catch2/catch.hpp>
+
+#include "stx/format.h"
+
+#include <cstring>
+
+using namespace std::string_literals;
+
+SCENARIO("format a string", "[stx::format::format]") {
+    GIVEN("An format string without any placeholder") {
+        auto fmt = GENERATE("", "test", "test string", ":-)");
+        auto r = stx::format(fmt);
+
+        THEN("Expecting the result to be equal to the format string") {
+            REQUIRE(r == fmt);
+        }
+    }
+
+    GIVEN("An format string without any placeholder, with escaped braces") {
+        std::pair<std::string_view, std::string_view> fmts[] = {
+            {"{",             ""},
+            {"{{",            "{"},
+            {"{{{{",          "{{"},
+            {"1{{2{{3",       "1{2{3"},
+            {"}",             ""},
+            {"}}",            "}"},
+            {"}}}}",          "}}"},
+            {"1{{2}}3",       "1{2}3"},
+            {"123{{abc}}321", "123{abc}321"},
+        };
+
+        THEN("Expecting the result to be equal to the format string") {
+            for (const auto& [fmt, expected] : fmts) {
+                INFO("Format: " << fmt);
+                INFO("Expected: " << expected);
+
+                auto r = stx::format(fmt);
+
+                REQUIRE(r == expected);
+            }
+        }
+    }
+
+    GIVEN("An format string with placeholders but no values") {
+        auto fmt = GENERATE("{}", "{}{}", "{1}{0}", "{:}{9:abc}");
+
+        THEN("Expecting the result to be empty") {
+            auto r = stx::format(fmt);
+
+            REQUIRE(r.empty());
+        }
+    }
+
+    GIVEN("An format string with no indices") {
+        auto fmt = "{}, {}, {}, {}, {}";
+
+        THEN("Expecting the right order of replacements") {
+            auto r = stx::format(fmt, 1, 2, 3, 4, 5);
+
+            REQUIRE(r == "1, 2, 3, 4, 5");
+        }
+    }
+
+    GIVEN("An format string with manual indices") {
+        auto fmt = "{4}, {3}, {2}, {1}, {0}";
+
+        THEN("Expecting the right order of replacements") {
+            auto r = stx::format(fmt, 1, 2, 3, 4, 5);
+
+            REQUIRE(r == "5, 4, 3, 2, 1");
+        }
+    }
+
+    GIVEN("An format string with mixed type of indices") {
+        auto fmt = "{4}, {}, {2}, {}, {3}";
+
+        THEN("Expecting the right order of replacements") {
+            auto r = stx::format(fmt, 1, 2, 3, 4, 5);
+
+            REQUIRE(r == "5, 1, 3, 2, 4");
+        }
+    }
+
+    GIVEN("An format string with an index out of range") {
+        auto fmt = "a={99}, b={999}";
+
+        THEN("Expecting no replacements") {
+            auto r = stx::format(fmt, 1, 2, 3);
+
+            REQUIRE(r == "a=, b=");
+        }
+    }
+
+    GIVEN("An format string with justify left") {
+        auto fmt = "{1:10}{:.<10}{:.<10}";
+
+        THEN("Expecting a left aligned string with . as fill char") {
+            auto r = stx::format(fmt, 123, "test");
+
+            REQUIRE(r == "test      123.......test......");
+        }
+    }
+
+    GIVEN("An format string with justify right") {
+        auto fmt = "{0:10}{:.>10}{:.>10}";
+
+        THEN("Expecting a right aligned string with . as fill char") {
+            auto r = stx::format(fmt, 123, "test");
+
+            REQUIRE(r == "       123.......123......test");
+        }
+    }
+
+    GIVEN("An format string with justify center") {
+        auto fmt = "{:.^10}{:-^10}{:,^7}{:=^7}";
+
+        THEN("Expecting a right aligned string with . as fill char") {
+            auto r = stx::format(fmt, 123, "test", 123, "test");
+
+            REQUIRE(r == "...123....---test---,,123,,=test==");
+        }
+    }
+
+    GIVEN("An format string with different integer bases") {
+        auto fmt = "{0:0b},{0:0o},{0:0d},{0:0x}";
+
+        THEN("Expecting a string containing the same number formatted with different bases") {
+            auto r = stx::format(fmt, 123);
+
+            REQUIRE(r == "1111011,173,123,7b");
+        }
+    }
+
+    GIVEN("An format string with a fillc and no width specified") {
+        auto fmt = "Hello{: }.";
+
+        THEN("Expecting a string with a space inbetween, if the template replaces with an non-empty string") {
+            auto r1 = stx::format(fmt, "Johannes");
+            REQUIRE(r1 == "Hello Johannes.");
+
+            auto r2 = stx::format(fmt, "");
+            REQUIRE(r2 == "Hello.");
+        }
+    }
+}


### PR DESCRIPTION
Implement a std::format 'like' function for formatting strings.
It's not as feature rich as C++20 std::format, though.

Nested template expressions are not supported (`"{:0<{}}", ..., ...`).