### PR TITLE
Add tests for `get_as_string`

### DIFF
--- a/include/stx/string.h
+++ b/include/stx/string.h
@@ -238,16 +238,18 @@ std::string to_string(_T&& v)
 namespace impl
 {
 
-template <std::size_t _Index>
+template <std::size_t _Index1>
 struct get_as_string
 {
+    static constexpr std::size_t Index0 = _Index1 - 1u;
+
     template <class... _Types>
     static std::string get(const std::size_t index,
                            const std::tuple<_Types...>& tuple)
     {
-        return index == _Index
-            ? stx::to_string(std::get<_Index>(tuple))
-            : get_as_string<_Index - 1u>::get(index, tuple);
+        return index == Index0
+            ? stx::to_string(std::get<Index0>(tuple))
+            : get_as_string<_Index1 - 1u>::get(index, tuple);
     }
 };
 
@@ -256,11 +258,9 @@ template <>
 struct get_as_string<0u>
 {
     template <class... _Types>
-    static std::string get(const std::size_t index,
-                           const std::tuple<_Types...>& tuple)
+    static std::string get(const std::size_t,
+                           const std::tuple<_Types...>&)
     {
-        if (index == 0u)
-            return stx::to_string(std::get<0u>(tuple));
         return {};
     }
 };
@@ -274,7 +274,7 @@ template <class _Tuple>
 std::string get_as_string(const std::size_t index,
                           const _Tuple& values)
 {
-    return impl::get_as_string<std::tuple_size_v<_Tuple> - 1u>::get(index, values);
+    return impl::get_as_string<std::tuple_size_v<_Tuple>>::get(index, values);
 }
 
 /**

--- a/test/src/string.cpp
+++ b/test/src/string.cpp
@@ -282,3 +282,32 @@ TEST_CASE("Range to hex string", "[stx::string::to_hex]") {
         REQUIRE(resu == "48616C6C6F2057656C7421");
     }
 }
+
+TEST_CASE("Get tuple values as string", "[stx::string::get_as_string]") {
+    SECTION("Empty tuple") {
+        auto t = std::tuple<>();
+        auto res = stx::get_as_string(0u, t);
+
+        REQUIRE(res.empty());
+    }
+
+    SECTION("Out of range") {
+        auto t = std::tuple<std::string>("Test");
+        auto res = stx::get_as_string(GENERATE(~0u, 1u), t);
+
+        REQUIRE(res.empty());
+    }
+
+    SECTION("Mixed tuple") {
+        auto t = std::tuple<int, float, std::string, bool>(7, 1.343f, "Test", true);
+        auto r1 = stx::get_as_string(0u, t);
+        auto r2 = stx::get_as_string(1u, t);
+        auto r3 = stx::get_as_string(2u, t);
+        auto r4 = stx::get_as_string(3u, t);
+
+        REQUIRE(r1 == "7");
+        REQUIRE(r2 == "1.343000");
+        REQUIRE(r3 == "Test");
+        REQUIRE(r4 == "1");
+    }
+}


### PR DESCRIPTION
Also make it possible to call `get_as_string` with an empty tuple.