### PR TITLE
Replace charconf from_chars and to_chars

### DIFF
--- a/include/stx/format.h
+++ b/include/stx/format.h
@@ -5,10 +5,10 @@
 #include <tuple>
 #include <cstring>
 #include <algorithm>
-#include <charconv>
 
 #include "formatter.h"
 #include "format_impl.h"
+#include "format_charconv_impl.h"
 
 namespace stx
 {
@@ -29,9 +29,8 @@ _Iter format_to(_Iter out, std::string_view fmt, const _Args& ...args)
             return;
 
         /* Parse optional argument index */
-        auto sv_begin = &(*begin);
-        if (auto r = std::from_chars(sv_begin, sv_begin + std::distance(begin, end), index); r.ptr != sv_begin) {
-            begin += r.ptr - sv_begin; /* MSVC does not accept: begin = r.ptr */
+        if (auto [iter, ok] = format_impl::parse_int(begin, end, index); ok) {
+            begin = iter;
         } else {
             index = next++; /* Auto incr. index */
         }

--- a/include/stx/format_charconv_impl.h
+++ b/include/stx/format_charconv_impl.h
@@ -1,0 +1,34 @@
+#pragma once
+
+namespace stx::format_impl
+{
+
+/**
+ * Parse an base-10 unsigned integer from range `begin` to `end`.
+ *
+ * Returns the iterator to the first non matching character, or `end`.
+ */
+template <class _Iter, class _Int>
+std::pair<_Iter, bool> parse_int(_Iter begin, _Iter end, _Int& out)
+{
+    static_assert(std::is_integral_v<_Int> && std::is_unsigned_v<_Int>,
+                  "Result type must be an unsigned integer type");
+
+    out = 0;
+
+    auto valid = false;
+    while (begin != end) {
+        if (*begin >= '0' && *begin <= '9') {
+            valid = true;
+            out *= 10;
+            out += *begin - '0';
+            ++begin;
+        } else {
+            break;
+        }
+    }
+
+    return {begin, valid};
+}
+
+}

--- a/include/stx/format_impl.h
+++ b/include/stx/format_impl.h
@@ -1,10 +1,11 @@
 #pragma once
 
 #include <string_view>
-#include <charconv>
+#include <type_traits>
 #include <optional>
 
 #include "formatter.h"
+#include "format_charconv_impl.h"
 
 namespace stx::format_impl
 {

--- a/test/src/format.cpp
+++ b/test/src/format.cpp
@@ -122,12 +122,18 @@ SCENARIO("format a string", "[stx::format::format]") {
     }
 
     GIVEN("A format string with different integer bases") {
-        auto fmt = "{0:0b},{0:0o},{0:0d},{0:0x}";
+        auto fmt = "{0:0o},{0:0d},{0:0x}";
 
         THEN("Expecting a string containing the same number formatted with different bases") {
             auto r = stx::format(fmt, 123);
 
-            REQUIRE(r == "1111011,173,123,7b");
+            REQUIRE(r == "173,123,7b");
+        }
+
+        THEN("Expecting a string containing the same number formatted with different bases (negative input)") {
+            auto r = stx::format(fmt, -123);
+
+            REQUIRE(r == "-173,-123,-7b");
         }
     }
 


### PR DESCRIPTION
With naive custom ~~`from_chars`~~`parse_int` implementation (for base 10 integers) and snprintf.
Why? Not all compilers we use ship `<charconv>`.