### PR TITLE
Add option_set implementation

### DIFF
--- a/include/stx/option-set.h
+++ b/include/stx/option-set.h
@@ -1,0 +1,265 @@
+#pragma once
+
+#include <optional>
+#include <tuple>
+#include <type_traits>
+
+namespace stx
+{
+
+template <class...>
+struct option_set;
+
+namespace impl
+{
+
+template <class>
+struct is_option_set : std::false_type {};
+
+template <class... _Types>
+struct is_option_set<option_set<_Types...>> : std::true_type {};
+
+template <class _Type>
+struct remove_optional
+{
+    using type = _Type;
+};
+
+template <class _Type>
+struct remove_optional<std::optional<_Type>>
+{
+    using type = _Type;
+};
+
+template <class _Type>
+using remove_optional_t = typename remove_optional<_Type>::type;
+
+template <class _Head, class...>
+struct unique_option_set
+{
+    using type = _Head;
+};
+
+template <class... _Types, class _Head, class... _Tail>
+struct unique_option_set<option_set<_Types...>, _Head, _Tail...>
+{
+    using type = std::conditional_t<(std::is_same_v<_Head, _Types> || ...),
+                                    typename unique_option_set<option_set<_Types...>, _Tail...>::type,
+                                    typename unique_option_set<option_set<_Types..., _Head>, _Tail...>::type>;
+};
+
+template <class... _Types>
+using unique_option_set_t = typename unique_option_set<option_set<>, _Types...>::type;
+
+template <class, class>
+struct merged_option_set;
+
+template <class... _First, class... _Second>
+struct merged_option_set<option_set<_First...>, option_set<_Second...>>
+{
+    using type = unique_option_set_t<remove_optional_t<_First>...,
+                                     remove_optional_t<_Second>...>;
+};
+
+template <class _Lhs, class _Rhs>
+using merged_option_set_t = typename merged_option_set<_Lhs, _Rhs>::type;
+
+}
+
+template <class... _Types>
+struct option_set : std::tuple<std::optional<_Types>...>
+{
+    option_set()
+    {}
+
+    template <class _Option,
+              class _Enable = std::enable_if_t<!impl::is_option_set<_Option>::value>>
+    option_set(_Option option)
+    {
+        set<_Option>(std::move(option));
+    }
+
+    template <class... _Options>
+    option_set(option_set<_Options...> rhs)
+    {
+        set(std::move(rhs));
+    }
+
+    option_set(const option_set& rhs)
+    {
+        set(rhs);
+    }
+
+    auto set(const option_set& rhs) -> option_set&
+    {
+        return *this = rhs;
+    }
+
+    template <class _Option, class _Enable = std::enable_if_t<!impl::is_option_set<_Option>::value>>
+    auto set(_Option rhs) -> option_set&
+    {
+        std::get<std::optional<std::decay_t<_Option>>>(*this) =
+            std::move(rhs);
+        return *this;
+    }
+
+    template <class... _RTypes>
+    auto set(option_set<_RTypes...>&& rhs) -> option_set&
+    {
+        (void)((std::get<std::optional<_RTypes>>(*this) =
+                std::move(std::get<std::optional<_RTypes>>(rhs))) && ...);
+        return *this;
+    }
+
+    template <class _Option>
+    auto has() const -> bool
+    {
+        return std::get<std::optional<_Option>>(*this) != std::nullopt;
+    }
+
+    template <class _Option>
+    auto get() const -> const _Option*
+    {
+        if (decltype(auto) option = std::get<std::optional<_Option>>(*this))
+            return &*option;
+        return nullptr;
+    }
+
+    /* Operators */
+
+    template <class... _RTypes>
+    auto operator|=(option_set<_RTypes...> rhs) -> option_set&
+    {
+        return set(std::move(rhs));
+    }
+
+    template <class _Option>
+    auto operator|=(_Option&& rhs) -> option_set&
+    {
+        return set(std::forward<_Option>(rhs));
+    }
+
+    template <class... _RTypes>
+    auto operator|(option_set<_RTypes...> rhs) const &
+    {
+        return impl::merged_option_set_t<option_set, option_set<_RTypes...>>()
+            .set(*this)
+            .set(std::move(rhs));
+    }
+
+    template <class... _RTypes>
+    auto operator|(option_set<_RTypes...> rhs) &&
+    {
+        return impl::merged_option_set_t<option_set, option_set<_RTypes...>>()
+            .set(std::move(*this))
+            .set(std::move(rhs));
+    }
+
+    template <class _Option,
+              class _Enable = std::enable_if_t<!impl::is_option_set<_Option>::value>>
+    auto operator|(_Option rhs) const &
+    {
+        return impl::merged_option_set_t<option_set, option_set<std::decay_t<_Option>>>()
+            .set(*this)
+            .template set<_Option>(std::move(rhs));
+    }
+
+    template <class _Option,
+              class _Enable = std::enable_if_t<!impl::is_option_set<_Option>::value>>
+    auto operator|(_Option rhs) &&
+    {
+        return impl::merged_option_set_t<option_set, option_set<std::decay_t<_Option>>>()
+            .set(std::move(*this))
+            .template set<_Option>(std::move(rhs));
+    }
+};
+
+/**
+ * Declare option type concat (|) operators.
+ *
+ * Example:
+ *   struct MyOption {
+ *     STX_OPTION_OPERATORS()
+ *
+ *     bool force = false;
+ *     bool verbose = false;
+ *   };
+ *
+ *   my_function(OtherOption() | MyOption());
+ */
+#define STX_OPTION_OPERATORS()                                          \
+    template <class _Other>                                             \
+    auto operator|(_Other rhs) const                                    \
+    {                                                                   \
+        return stx::option_set<std::decay_t<decltype(*this)>, _Other>() \
+            .set(*this) | std::move(rhs);                               \
+    }                                                                   \
+                                                                        \
+    template <class... _RTypes>                                         \
+    auto operator|(stx::option_set<_RTypes...> rhs) const               \
+    {                                                                   \
+        return stx::option_set<std::decay_t<decltype(*this)>>()         \
+            .set(*this) | std::move(rhs);                               \
+    }
+
+/**
+ * Declare a simple (on/off) option type.
+ *
+ * Example:
+ *   STX_DECLARE_FLAG_OPTION(FollowSymlinks)
+ *   STX_DECLARE_FLAG_OPTION(Recursive)
+ *
+ *   my_function(FollowSymlinks() | Recursive())
+ */
+#define STX_DECLARE_FLAG_OPTION(ident)          \
+    struct ident { STX_OPTION_OPERATORS() };
+
+namespace option_kw
+{
+
+template <class _Type, class>
+struct kwarg
+{
+    struct option_type
+    {
+        _Type value;
+
+        operator _Type&() {return value;}
+        operator const _Type&() const {return value;}
+
+        auto operator==(const _Type& rhs) const { return value == rhs; }
+        auto operator!=(const _Type& rhs) const { return value != rhs; }
+
+        STX_OPTION_OPERATORS();
+    };
+
+    option_type operator=(_Type value) const
+    {
+        return option_type{std::move(value)};
+    }
+};
+
+/**
+ * Declare keyword-argument like option type.
+ *
+ * Parameters:
+ *   ident  Unique type identifier
+ *   type   Value type
+ *
+ * Creates a unique type `ident` and a static constant variable indent + '_'.
+ *
+ * Example:
+ *   STX_DECLARE_KWARG(Name);
+ *   STX_DECLARE_KWARG(Age);
+ *
+ *   my_function((Name_ = "Johannes") | (Age_ = 27)); // <- Note the '_' for assigning kwargs.
+ *   ...
+ *   { args.get<Name>() ... } // <- Use the ident (without '_') for access.
+ */
+#define STX_DECLARE_KWARG(ident, type)                                                  \
+    static const stx::option_kw::kwarg<type, struct ident ## __uniqkwarg__> ident ## _; \
+    using ident = typename decltype(ident ## _)::option_type;                           \
+
+}
+
+}

--- a/include/stx/unique-tuple.h
+++ b/include/stx/unique-tuple.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <tuple>
+#include <type_traits>
+
+namespace stx
+{
+
+template <class _Head, class...>
+struct unique
+{
+    using type = _Head;
+};
+
+template <class... _Types, class _Head, class... _Tail>
+struct unique<std::tuple<_Types...>, _Head, _Tail...>
+    : std::conditional_t<(std::is_same_v<_Head, _Tail> || ...),          /* If head in tail. */
+                         unique<std::tuple<_Types...>, _Tail...>,        /* Skip head. */
+                         unique<std::tuple<_Types..., _Head>, _Tail...>> /* Append head. */
+{};
+
+template <class... _Types>
+using unique_tuple = typename unique<std::tuple<>, _Types...>::type;
+
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(stx-test
   src/string.cpp
   src/format.cpp
   src/unique-tuple.cpp
+  src/option-set.cpp
   src/map.cpp)
 
 target_compile_options(stx-test

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(stx-test
   src/main.cpp
   src/string.cpp
   src/format.cpp
+  src/unique-tuple.cpp
   src/map.cpp)
 
 target_compile_options(stx-test

--- a/test/src/option-set.cpp
+++ b/test/src/option-set.cpp
@@ -1,0 +1,123 @@
+#include <catch2/catch.hpp>
+
+#include "stx/option-set.h"
+
+#include <string>
+
+struct A { STX_OPTION_OPERATORS() };
+struct B { STX_OPTION_OPERATORS() };
+struct C { STX_OPTION_OPERATORS() };
+struct D { STX_OPTION_OPERATORS() };
+
+namespace kw
+{
+STX_DECLARE_KWARG(NAME, std::string)
+STX_DECLARE_KWARG(AGE,  int)
+}
+
+std::string my_function(stx::option_set<kw::NAME, kw::AGE> options)
+{
+    return options.get<kw::NAME>()->value + " (" + std::to_string(*options.get<kw::AGE>()) + ")";
+}
+
+SCENARIO("option set", "[stx::option_set]") {
+    GIVEN("An empty option set") {
+        (void)stx::option_set<>();
+    }
+
+    GIVEN("Merging multiple options into an option_set") {
+        auto set = A() | B() | C();
+
+        THEN("Expecting the option_set type to hold all option types") {
+            REQUIRE(std::is_same_v<stx::option_set<A, B, C>, decltype(set)>);
+        }
+
+        THEN("Expecting all options to be set") {
+            REQUIRE(set.has<A>());
+            REQUIRE(set.has<B>());
+            REQUIRE(set.has<C>());
+        }
+
+        THEN("Merging in duplicate types") {
+            auto set2 = set | C() | B ();
+
+            THEN("Expecting the new option_set type to be unchanged") {
+                REQUIRE(std::is_same_v<stx::option_set<A, B, C>, decltype(set2)>);
+            }
+        }
+
+        THEN("Merging in new types (rhs)") {
+            auto set2 = set | D();
+
+            THEN("Expecting the new option_set to contain type C") {
+                REQUIRE(std::is_same_v<stx::option_set<A, B, C, D>, decltype(set2)>);
+            }
+        }
+
+        THEN("Merging in new types (lhs)") {
+            auto set2 = D() | set;
+
+            THEN("Expecting the new option_set to contain type C") {
+                REQUIRE(std::is_same_v<stx::option_set<D, A, B, C>, decltype(set2)>);
+            }
+        }
+
+        THEN("Assigning the set to a fixed set variable") {
+            auto fixed = stx::option_set<A, B, C>();
+            THEN("Expecting all options to be unset") {
+                REQUIRE(!fixed.has<A>());
+                REQUIRE(!fixed.has<B>());
+                REQUIRE(!fixed.has<C>());
+            }
+
+            fixed = set;
+            THEN("Expecting all options to be set") {
+                REQUIRE(fixed.has<A>());
+                REQUIRE(fixed.has<B>());
+                REQUIRE(fixed.has<C>());
+            }
+        }
+    }
+
+    GIVEN("An kwarg option set") {
+        auto set = (kw::NAME_ = "Johannes") | (kw::AGE_ = 27);
+
+        THEN("Expecting a set with two options") {
+            REQUIRE(set.has<kw::NAME>());
+            REQUIRE(set.has<kw::AGE>());
+
+            THEN("Checking option values (==/!=)") {
+                REQUIRE(*set.get<kw::NAME>() == "Johannes");
+                REQUIRE(*set.get<kw::NAME>() != "Jochen");
+
+                REQUIRE(*set.get<kw::AGE>() == 27);
+                REQUIRE(*set.get<kw::AGE>() != 3);
+            }
+
+            THEN("Copy out option values") {
+                std::string name = *set.get<kw::NAME>();
+                (void)name;
+
+                int age = *set.get<kw::AGE>();
+                (void)age;
+            }
+
+            THEN("Merging a non-kwarg option") {
+                auto set2 = set | A();
+
+                REQUIRE(std::is_same_v<stx::option_set<kw::NAME, kw::AGE, A>, decltype(set2)>);
+            }
+
+            THEN("Passing set to a function") {
+                REQUIRE(my_function(set) == "Johannes (27)");
+            }
+
+            THEN("Overwriting kwargs") {
+                set |= kw::NAME_ = "Peter";
+                set |= kw::AGE_ = 5;
+
+                REQUIRE(my_function(set) == "Peter (5)");
+            }
+        }
+    }
+}

--- a/test/src/unique-tuple.cpp
+++ b/test/src/unique-tuple.cpp
@@ -1,0 +1,21 @@
+#include <catch2/catch.hpp>
+
+#include "stx/unique-tuple.h"
+
+SCENARIO("unique tuple", "[stx::unique_tuple]") {
+    GIVEN("A tuple with unique types") {
+        auto t = stx::unique_tuple<int, float, bool>();
+
+        THEN("Expecting a tuple size of three") {
+            REQUIRE(std::tuple_size_v<decltype(t)> == 3);
+        }
+    }
+
+    GIVEN("A tuple with repeating types") {
+        auto t = stx::unique_tuple<bool, int, float, int, bool, float, float>();
+
+        THEN("Expecting a tuple size of three") {
+            REQUIRE(std::tuple_size_v<decltype(t)> == 3);
+        }
+    }
+}


### PR DESCRIPTION
Implementation of `option_set` as a replacement for bitmasks/flags.

Usage:
```c
STX_DECLARE_FLAG_OPTION(MyOptionA)
STX_DECLARE_FLAG_OPTION(MyOptionB)

auto options = MyOptionA() | MyOptionB(); // Combine using '|'

auto is_a = options.has<MyOptionA>(); // Test using has<T>()
```

And kwargs like options:
```c
namespace kw {
STX_DECLARE_KWARG(Name, std::string) // Creates a type `Name` and a constant 'Name_'. The later can be used for assignment.
STX_DECLARE_KWARG(Age, int)
}

auto options = (kw::Name_ = "Peter Pan") | (kw::Age_ = 0); // Set using ident + '_' and '='  operator.
// ... or use ctor:
auto options = kw::Name("Peter Pan") | kw::Age(0);

auto name = *options.get<Name>(); // Get using ident.
```