### PR TITLE
Upgrade to Catch2 3.1.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "test/deps/Catch2"]
-	path = test/deps/Catch2
-	url = https://github.com/catchorg/Catch2.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,10 +3,12 @@ enable_testing()
 
 include(FetchContent)
 
+project(stx)
+
 # Do not build tests, if stx is bundled
-if (NOT DEFINED PROJECT_NAME)
-  project(stx)
-  set(NOT_SUBPROJECT ON)
+set(MAIN_PROJECT OFF)
+if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+  set(MAIN_PROJECT ON)
 endif()
 
 add_library(stx INTERFACE)
@@ -21,6 +23,6 @@ target_compile_features(stx
 
 add_library(stx::stx ALIAS stx)
 
-if (NOT_SUBPROJECT)
+if (MAIN_PROJECT)
   add_subdirectory(test)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.14.0)
 enable_testing()
 
+include(FetchContent)
+
 # Do not build tests, if stx is bundled
 if (NOT DEFINED PROJECT_NAME)
   project(stx)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,12 +1,14 @@
 project(stx-test)
 
-if (NOT TARGET Catch2::Catch2)
-  unset(NOT_SUBPROJECT)
-  add_subdirectory(deps/Catch2)
+if (NOT TARGET Catch2)
+  FetchContent_Declare(Catch2
+    GIT_REPOSITORY "https://github.com/catchorg/Catch2.git"
+    GIT_TAG        "v3.1.0"
+    GIT_SHALLOW    ON)
+  FetchContent_MakeAvailable(Catch2)
 endif()
 
 add_executable(stx-test
-  src/main.cpp
   src/string.cpp
   src/format.cpp
   src/unique-tuple.cpp
@@ -21,8 +23,7 @@ target_compile_options(stx-test
 target_link_libraries(stx-test
   PUBLIC
     stx
-    Catch2::Catch2)
+    Catch2::Catch2WithMain)
 
 include(CTest)
-add_test(NAME stx-test
-  COMMAND "$<TARGET_FILE:stx-test>")
+add_test(NAME stx-test COMMAND "$<TARGET_FILE:stx-test>")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 project(stx-test)
 
+set(CMAKE_CXX_STANDARD 17) # Required for catch2
 if (NOT TARGET Catch2)
   FetchContent_Declare(Catch2
     GIT_REPOSITORY "https://github.com/catchorg/Catch2.git"
@@ -14,6 +15,10 @@ add_executable(stx-test
   src/unique-tuple.cpp
   src/option-set.cpp
   src/map.cpp)
+
+target_compile_features(stx-test
+  PUBLIC
+    cxx_std_17)
 
 target_compile_options(stx-test
   PRIVATE

--- a/test/src/format.cpp
+++ b/test/src/format.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "stx/format.h"
 

--- a/test/src/main.cpp
+++ b/test/src/main.cpp
@@ -1,2 +1,0 @@
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>

--- a/test/src/map.cpp
+++ b/test/src/map.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_all.hpp>
 
 #include <map>
 #include <unordered_map>

--- a/test/src/map.cpp
+++ b/test/src/map.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <map>
 #include <unordered_map>

--- a/test/src/option-set.cpp
+++ b/test/src/option-set.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "stx/option-set.h"
 

--- a/test/src/string.cpp
+++ b/test/src/string.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "stx/string.h"
 

--- a/test/src/string.cpp
+++ b/test/src/string.cpp
@@ -124,13 +124,18 @@ SCENARIO("split a string into parts", "[stx::string::split]") {
 
         auto r = stx::split<std::vector<std::string_view>>(in, "/");
 
+        std::vector<std::string> o;
+        std::transform(r.begin(), r.end(), std::back_inserter(o), [](const auto& v) {
+            return std::string(v);
+        });
+
         THEN("Expecting five elements (a, b, c, d, e)") {
-            REQUIRE(r.size() == 5);
-            REQUIRE(r.at(0) == "a");
-            REQUIRE(r.at(1) == "b");
-            REQUIRE(r.at(2) == "c");
-            REQUIRE(r.at(3) == "d");
-            REQUIRE(r.at(4) == "e");
+            REQUIRE(o.size() == 5);
+            REQUIRE(o.at(0) == "a");
+            REQUIRE(o.at(1) == "b");
+            REQUIRE(o.at(2) == "c");
+            REQUIRE(o.at(3) == "d");
+            REQUIRE(o.at(4) == "e");
         }
     }
 }

--- a/test/src/unique-tuple.cpp
+++ b/test/src/unique-tuple.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include "stx/unique-tuple.h"
 


### PR DESCRIPTION
Upgrade Catch2 dependency to 3.1.0 (also fixes a build-issue on fedora 36).